### PR TITLE
Fix Payment Processor Duplicated Addresses Bug

### DIFF
--- a/libs/paymentProcessor.js
+++ b/libs/paymentProcessor.js
@@ -377,13 +377,11 @@ function SetupForPool(logger, poolOptions, setupFinished){
                         if (toSend >= minPaymentSatoshis) {
                             totalSent += toSend;
                             var address = worker.address = (worker.address || getProperAddress(w)).trim();
-                        if (!worker.sent) {
-                            worker.sent = 0;
-                            }
-                        worker.sent += satoshisToCoins(toSend);
-                        if (!(address in addressAmounts)) {
-                            addressAmounts[address] = 0;
-                            }
+                            if (!worker.sent)
+                                worker.sent = 0;
+                            worker.sent += satoshisToCoins(toSend);
+                            if (!(address in addressAmounts))
+                                addressAmounts[address] = 0;
                             addressAmounts[address] += satoshisToCoins(toSend);
                             worker.balanceChange = Math.min(worker.balance, toSend) * -1;
                         }

--- a/libs/paymentProcessor.js
+++ b/libs/paymentProcessor.js
@@ -376,8 +376,15 @@ function SetupForPool(logger, poolOptions, setupFinished){
                         var toSend = (worker.balance + worker.reward) * (1 - withholdPercent);
                         if (toSend >= minPaymentSatoshis) {
                             totalSent += toSend;
-                            var address = worker.address = (worker.address || getProperAddress(w));
-                            worker.sent = addressAmounts[address] = satoshisToCoins(toSend);
+                            var address = worker.address = (worker.address || getProperAddress(w)).trim();
+                        if (!worker.sent) {
+                            worker.sent = 0;
+                            }
+                        worker.sent += satoshisToCoins(toSend);
+                        if (!(address in addressAmounts)) {
+                            addressAmounts[address] = 0;
+                            }
+                            addressAmounts[address] += satoshisToCoins(toSend);
                             worker.balanceChange = Math.min(worker.balance, toSend) * -1;
                         }
                         else {


### PR DESCRIPTION
NOMP for some reason accepts spaces before or after Legacy Addresses, and if someone uses multiple miners with different spacings in the address, NOMP will attempt to create transactions involving the same address multiple times, which is not allowed by Riecoin Core, preventing payouts.